### PR TITLE
Format code according to go1.19rc2

### DIFF
--- a/log/checkpoint.go
+++ b/log/checkpoint.go
@@ -44,9 +44,10 @@ func (c Checkpoint) Marshal() []byte {
 //
 // The supplied data is expected to begin with the following 3 lines of text,
 // each followed by a newline:
-//  - <ecosystem/version string>
-//  - <decimal representation of log size>
-//  - <base64 representation of root hash>
+//   - <ecosystem/version string>
+//   - <decimal representation of log size>
+//   - <base64 representation of root hash>
+//
 // Any trailing data after this will be returned.
 func (c *Checkpoint) Unmarshal(data []byte) ([]byte, error) {
 	l := bytes.SplitN(data, []byte("\n"), 4)


### PR DESCRIPTION
Go formatting of docs has changed a little in 1.19: https://tip.golang.org/doc/go1.19\#go-doc. This formats the code in this repo so the docs are consistent with that. Previous versions of gofmt won't change this, and this allows old and new tooling to render the docs in increasingly better ways.

Announcement for 1.19rc2: https://groups.google.com/g/golang-announce/c/czoG5UpT0EU
