### PR TITLE
Tighten action permissions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,6 +20,9 @@ on:
   schedule:
     - cron: '22 20 * * 5'
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/go_test.yml
+++ b/.github/workflows/go_test.yml
@@ -1,5 +1,7 @@
 on: [push, pull_request]
 name: Test Go
+permissions:
+  contents: read
 jobs:
   test:
     strategy:


### PR DESCRIPTION
Explicitly restrict CodeQL and go_test actions to be read-only.