### PR TITLE
Breaking change: Change the log ID function to also include the origin string

### DIFF
--- a/log/identifier.go
+++ b/log/identifier.go
@@ -24,5 +24,10 @@ import (
 // for this log at distributors, and that will be used to feed
 // checkpoints to witnesses.
 func ID(origin string, key []byte) string {
-	return fmt.Sprintf("%x", sha256.Sum256(key))
+	// Hash both the origin and key, and then hash them together
+	// to create the final ID.
+	oh := sha256.Sum256([]byte(origin))
+	kh := sha256.Sum256(key)
+	hashMe := append([]byte(oh[:]), kh[:]...)
+	return fmt.Sprintf("%x", sha256.Sum256(hashMe))
 }

--- a/log/identifier.go
+++ b/log/identifier.go
@@ -26,8 +26,10 @@ import (
 func ID(origin string, key []byte) string {
 	// Hash both the origin and key, and then hash them together
 	// to create the final ID.
-	oh := sha256.Sum256([]byte(origin))
-	kh := sha256.Sum256(key)
-	hashMe := append([]byte(oh[:]), kh[:]...)
-	return fmt.Sprintf("%x", sha256.Sum256(hashMe))
+	s := sha256.New()
+	s.Write([]byte("o:"))
+	s.Write([]byte(origin))
+	s.Write([]byte("\nk:"))
+	s.Write(key)
+	return fmt.Sprintf("%x", s.Sum(nil))
 }

--- a/log/identifier.go
+++ b/log/identifier.go
@@ -24,8 +24,6 @@ import (
 // for this log at distributors, and that will be used to feed
 // checkpoints to witnesses.
 func ID(origin string, key []byte) string {
-	// Hash both the origin and key, and then hash them together
-	// to create the final ID.
 	s := sha256.New()
 	s.Write([]byte("o:"))
 	s.Write([]byte(origin))

--- a/log/identifier_test.go
+++ b/log/identifier_test.go
@@ -31,31 +31,31 @@ func TestID(t *testing.T) {
 			desc:   "sumdb",
 			origin: "go.sum database tree",
 			pk:     []byte("sum.golang.org+033de0ae+Ac4zctda0e5eza+HJyk9SxEdh+s3Ux18htTTAD8OuAn8"),
-			want:   "e0b4aa62acca10f5bc40bb803eea643cba17a908bd9cf4e9ef8d736bac47fb48",
+			want:   "bdc0d5078d38fc2b9491df373eb7c0d3365bfe661c83edc89112fd38719dc3a0",
 		},
 		{
 			desc:   "usbarmory",
 			origin: "Armory Drive Prod 2",
 			pk:     []byte("armory-drive-log+16541b8f+AYDPmG5pQp4Bgu0a1mr5uDZ196+t8lIVIfWQSPWmP+Jv"),
-			want:   "4ad2fce3c699522bf81ef663bdc973e83a27ea1b8c92ea6d030747d73cd9dae8",
+			want:   "a49f0a631f86d3e4fc6726e4389d1cc1998731aa58be95e3e81026d35d2b2902",
 		},
 		{
 			desc:   "rekor 1",
 			origin: "rekor.sigstore.dev - 2605736670972794746",
 			pk:     []byte("rekor.sigstore.dev+c0d23d6a+AjBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABNhtmPtrWm3U1eQXBogSMdGvXwBcK5AW5i0hrZLOC96l+smGNM7nwZ4QvFK/4sueRoVj//QP22Ni4Qt9DPfkWLc="),
-			want:   "afc7cd5295b43e3d95c4058b9e115b3760c71b9cd2f5c3104e121bd9970359b9",
+			want:   "50ed07082843287df5342353a4084563e6eaeb7bbaaa961d45400dde004c1186",
 		},
 		{
 			desc:   "rekor 2",
 			origin: "rekor.sigstore.dev - 3904496407287907110",
 			pk:     []byte("rekor.sigstore.dev+c0d23d6a+AjBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABNhtmPtrWm3U1eQXBogSMdGvXwBcK5AW5i0hrZLOC96l+smGNM7nwZ4QvFK/4sueRoVj//QP22Ni4Qt9DPfkWLc="),
-			want:   "5be31cffff16384a6f6fa895b2bf3bb510d7b59197fb488e6e0aaf9d1b72d9ad",
+			want:   "9b2bc13a3839d8a954832caa002ce8d7fb3d0bf7f4ce4a310a7dbbf28de101a8",
 		},
 		{
 			desc:   "rekor 3",
 			origin: "rekor.sigstore.dev - 3904496407287907110",
 			pk:     []byte("armory-drive-log+16541b8f+AYDPmG5pQp4Bgu0a1mr5uDZ196+t8lIVIfWQSPWmP+Jv"),
-			want:   "750e9a8dc89eb1334fc53db4d8feb94acf4e45c2e7f5dd00d08c665e6fbc8483",
+			want:   "27ad43bd0470950078c0aeb4bd7293d8dc6e47cb969f18aa958f1db6dd27b337",
 		},
 	} {
 		t.Run(test.desc, func(t *testing.T) {

--- a/log/identifier_test.go
+++ b/log/identifier_test.go
@@ -31,13 +31,13 @@ func TestID(t *testing.T) {
 			desc:   "sumdb",
 			origin: "go.sum database tree",
 			pk:     []byte("sum.golang.org+033de0ae+Ac4zctda0e5eza+HJyk9SxEdh+s3Ux18htTTAD8OuAn8"),
-			want:   "3e9617dce5730053cb82f0481b9d289cd3c384a9219ef5509c91aa60d214794e",
+			want:   "e0b4aa62acca10f5bc40bb803eea643cba17a908bd9cf4e9ef8d736bac47fb48",
 		},
 		{
 			desc:   "usbarmory",
 			origin: "Armory Drive Prod 2",
 			pk:     []byte("armory-drive-log+16541b8f+AYDPmG5pQp4Bgu0a1mr5uDZ196+t8lIVIfWQSPWmP+Jv"),
-			want:   "50dfc1866b26a18b65834743645f90737c331bc5e99b44100e5ca555c17821e3",
+			want:   "4ad2fce3c699522bf81ef663bdc973e83a27ea1b8c92ea6d030747d73cd9dae8",
 		},
 	} {
 		t.Run(test.desc, func(t *testing.T) {

--- a/log/identifier_test.go
+++ b/log/identifier_test.go
@@ -39,6 +39,24 @@ func TestID(t *testing.T) {
 			pk:     []byte("armory-drive-log+16541b8f+AYDPmG5pQp4Bgu0a1mr5uDZ196+t8lIVIfWQSPWmP+Jv"),
 			want:   "4ad2fce3c699522bf81ef663bdc973e83a27ea1b8c92ea6d030747d73cd9dae8",
 		},
+		{
+			desc:   "rekor 1",
+			origin: "rekor.sigstore.dev - 2605736670972794746",
+			pk:     []byte("rekor.sigstore.dev+c0d23d6a+AjBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABNhtmPtrWm3U1eQXBogSMdGvXwBcK5AW5i0hrZLOC96l+smGNM7nwZ4QvFK/4sueRoVj//QP22Ni4Qt9DPfkWLc="),
+			want:   "afc7cd5295b43e3d95c4058b9e115b3760c71b9cd2f5c3104e121bd9970359b9",
+		},
+		{
+			desc:   "rekor 2",
+			origin: "rekor.sigstore.dev - 3904496407287907110",
+			pk:     []byte("rekor.sigstore.dev+c0d23d6a+AjBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABNhtmPtrWm3U1eQXBogSMdGvXwBcK5AW5i0hrZLOC96l+smGNM7nwZ4QvFK/4sueRoVj//QP22Ni4Qt9DPfkWLc="),
+			want:   "5be31cffff16384a6f6fa895b2bf3bb510d7b59197fb488e6e0aaf9d1b72d9ad",
+		},
+		{
+			desc:   "rekor 3",
+			origin: "rekor.sigstore.dev - 3904496407287907110",
+			pk:     []byte("armory-drive-log+16541b8f+AYDPmG5pQp4Bgu0a1mr5uDZ196+t8lIVIfWQSPWmP+Jv"),
+			want:   "750e9a8dc89eb1334fc53db4d8feb94acf4e45c2e7f5dd00d08c665e6fbc8483",
+		},
 	} {
 		t.Run(test.desc, func(t *testing.T) {
 			if got, want := log.ID(test.origin, test.pk), test.want; got != want {


### PR DESCRIPTION
This fixes #14. Any stateless servers running that are keyed by ID here will need manual fiddling. A fresh start is probably the easiest thing to do. This will affect witnesses and distributors.