### PR TITLE
Update linter action and version, and auto-update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,12 @@
 version: 2
 updates:
 - package-ecosystem: gomod
-  directory: "/"
+  directory: /
   schedule:
-    interval: weekly
-  open-pull-requests-limit: 10
+    interval: daily
+
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: daily
+

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,7 +16,7 @@ jobs:
           go-version: 1.19
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@07db5389c99593f11ad7b44463c2d4233066a9b1 # v3.3.0
+        uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3.7.0
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.51.1
+          version: v1.54.1


### PR DESCRIPTION
Set up auto update for github actions in this repo. Manually updated to latest version of the action and use the latest version of the ruleset while I'm here.
