### PR TITLE
Updated Slack channel details

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/transparency-dev/formats)](https://goreportcard.com/report/github.com/transparency-dev/formats)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/transparency-dev/formats/badge)](https://securityscorecards.dev/viewer/?uri=github.com/transparency-dev/formats)
 [![codecov](https://codecov.io/gh/transparency-dev/formats/branch/main/graph/badge.svg?token=BBCRAMOBY2)](https://codecov.io/gh/transparency-dev/formats)
-[![Slack Status](https://img.shields.io/badge/Slack-Chat-blue.svg)](https://gtrillian.slack.com/)
+[![Slack Status](https://img.shields.io/badge/Slack-Chat-blue.svg)](https://transparency-dev.slack.com/)
 
 ## Overview
 
@@ -26,4 +26,4 @@ state of a transparent log.
 
 ## Support
 * Mailing list: https://groups.google.com/forum/#!forum/trillian-transparency
-* Slack: https://gtrillian.slack.com/ (invitation)
+- Slack: https://transparency-dev.slack.com/ ([invitation](https://join.slack.com/t/transparency-dev/shared_invite/zt-27pkqo21d-okUFhur7YZ0rFoJVIOPznQ))


### PR DESCRIPTION
Old slack channel will stay around for a while, but we're migrating over to a new channel that encompasses a broader transparency community that includes common formats and other transparency topics.
