### PR TITLE
Bump golangci lint

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           go-version-file: go.mod
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6.5.2
+        uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7.0.0
         with:
-          # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.64.6
+          version: v2.0.1
+          args: --timeout=8m

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,18 +1,24 @@
-run:
-  # timeout for analysis, e.g. 30s, 5m, default is 1m
-  timeout: 90s
-
-linters-settings:
-  gocyclo:
-    # minimal code complexity to report, 30 by default (but we recommend 10-20)
-    min-complexity: 25
-  depguard:
-    rules:
-      main:
-        deny:
-          - pkg: "golang.org/x/net/context"
-          - pkg: "github.com/gogo/protobuf/proto"
-
-issues:
-  # Don't turn off any checks by default. We can do this explicitly if needed.
-  exclude-use-default: false
+version: "2"
+linters:
+  settings:
+    depguard:
+      rules:
+        main:
+          deny:
+            - pkg: golang.org/x/net/context
+            - pkg: github.com/gogo/protobuf/proto
+    gocyclo:
+      min-complexity: 25
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -11,14 +11,6 @@ linters:
       min-complexity: 25
   exclusions:
     generated: lax
-    paths:
-      - third_party$
-      - builtin$
-      - examples$
 formatters:
   exclusions:
     generated: lax
-    paths:
-      - third_party$
-      - builtin$
-      - examples$


### PR DESCRIPTION
This PR bumps `golangci-lint@v2` and migrates the config file.

Should unblock #182.