### PR TITLE
Added function to generate vkey from skey

### DIFF
--- a/note/note_verifier.go
+++ b/note/note_verifier.go
@@ -30,10 +30,10 @@ import (
 	"golang.org/x/mod/sumdb/note"
 )
 
-// SignerVerifierFromEd25519Key returns a note Signer and Verifier given an
+// NewEd25519SignerVerifier returns a note Signer and Verifier given an
 // Ed25519 private key in the standard note-formatted form, e.g.
 // `PRIVATE+KEY+logandmap+38581672+AXJ0FKWOcO2ch6WC8kP705Ed3Gxu7pVtZLhfHAQwp+FE`.
-func SignerVerifierFromEd25519Key(skey string) (note.Signer, note.Verifier, error) {
+func NewEd25519SignerVerifier(skey string) (note.Signer, note.Verifier, error) {
 	const algEd25519 = 1
 	s, err := note.NewSigner(skey)
 	if err != nil {
@@ -52,27 +52,23 @@ func SignerVerifierFromEd25519Key(skey string) (note.Signer, note.Verifier, erro
 	}
 
 	alg, key := key[0], key[1:]
-	switch alg {
-	default:
+	if alg != algEd25519 {
 		return nil, nil, errors.New("unsupported algorithm")
-
-	case algEd25519:
-		if len(key) != ed25519.SeedSize {
-			return nil, nil, fmt.Errorf("expected key seed of size %d but got %d", ed25519.SeedSize, len(key))
-		}
-		key := ed25519.NewKeyFromSeed(key)
-		publicKey := key.Public().(ed25519.PublicKey)
-		vkey, err := note.NewEd25519VerifierKey(s.Name(), publicKey)
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to generate verifier from key: %v", err)
-
-		}
-		v, err := note.NewVerifier(vkey)
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to create verifier from vkey: %v", err)
-		}
-		return s, v, err
 	}
+	if l := len(key); l != ed25519.SeedSize {
+		return nil, nil, fmt.Errorf("expected key seed of size %d but got %d", ed25519.SeedSize, l)
+	}
+	publicKey := ed25519.NewKeyFromSeed(key).Public().(ed25519.PublicKey)
+	vkey, err := note.NewEd25519VerifierKey(s.Name(), publicKey)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to generate verifier from key: %v", err)
+
+	}
+	v, err := note.NewVerifier(vkey)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create verifier from vkey: %v", err)
+	}
+	return s, v, err
 }
 
 // NewVerifier returns a verifier for the given key, if the key's algo is known.

--- a/note/note_verifier_test.go
+++ b/note/note_verifier_test.go
@@ -50,7 +50,7 @@ func TestSignerVerifierFromEd25519Key(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			s, v, err := SignerVerifierFromEd25519Key(test.key)
+			s, v, err := NewEd25519SignerVerifier(test.key)
 			if gotErr := err != nil; gotErr != test.wantErr {
 				t.Fatalf("NewVerifier: %v, wantErr %t", err, test.wantErr)
 			}

--- a/note/note_verifier_test.go
+++ b/note/note_verifier_test.go
@@ -33,6 +33,42 @@ const (
 	pixelKey         = "pixel6_transparency_log" + "+" + pixelKeyHash + "+" + pixelKeyMaterial
 )
 
+func TestSignerVerifierFromEd25519Key(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		key     string
+		wantErr bool
+	}{
+		{
+			name: "Ed25519 private key",
+			key:  "PRIVATE+KEY+logandmap+38581672+AXJ0FKWOcO2ch6WC8kP705Ed3Gxu7pVtZLhfHAQwp+FE",
+		},
+		{
+			name:    "Ed25519 public key",
+			key:     "logandmap+38581672+Ab/PCr1eCclRPRMBqw/r5An1xO71MCnImLiospEq6b4l",
+			wantErr: true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			s, v, err := SignerVerifierFromEd25519Key(test.key)
+			if gotErr := err != nil; gotErr != test.wantErr {
+				t.Fatalf("NewVerifier: %v, wantErr %t", err, test.wantErr)
+			}
+			if test.wantErr {
+				return
+			}
+			msg := []byte("hello")
+			sig, err := s.Sign(msg)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !v.Verify(msg, sig) {
+				t.Fatal("Failed to verify signature from signer")
+			}
+		})
+	}
+}
+
 func TestNewVerifier(t *testing.T) {
 	for _, test := range []struct {
 		name    string


### PR DESCRIPTION
This is scoped only to Ed25519 keys. This comes up in many implementations where an operator wants to sign new messages, but also authenticate previous messages they may have made (e.g. witnesses, logs).
