### PR TITLE
Copy witness policy file format code from Tessera

### DIFF
--- a/witness/witness_policy_test.go
+++ b/witness/witness_policy_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 )
 
-func TestNewWitnessGroupFromPolicy(t *testing.T) {
+func TestParsePolicy(t *testing.T) {
 	for _, test := range []struct {
 		name   string
 		policy string
@@ -50,9 +50,9 @@ group      g1    all     w1  w2
 	} {
 		t.Run(test.name, func(t *testing.T) {
 
-			wg, err := NewWitnessGroupFromPolicy([]byte(test.policy))
+			wg, err := ParsePolicy([]byte(test.policy))
 			if err != nil {
-				t.Fatalf("NewWitnessGroupFromPolicy() failed: %v", err)
+				t.Fatalf("ParsePolicy() failed: %v", err)
 			}
 
 			if wg.N != 2 {
@@ -65,7 +65,7 @@ group      g1    all     w1  w2
 	}
 }
 
-func TestNewWitnessGroupFromPolicy_GroupN(t *testing.T) {
+func TestParsePolicy_GroupN(t *testing.T) {
 	testCases := []struct {
 		desc   string
 		policy string
@@ -109,9 +109,9 @@ quorum g1
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			wg, err := NewWitnessGroupFromPolicy([]byte(tc.policy))
+			wg, err := ParsePolicy([]byte(tc.policy))
 			if err != nil {
-				t.Fatalf("NewWitnessGroupFromPolicy() failed: %v", err)
+				t.Fatalf("ParsePolicy() failed: %v", err)
 			}
 			if wg.N != tc.wantN {
 				t.Errorf("wg.N = %d, want %d", wg.N, tc.wantN)
@@ -120,7 +120,7 @@ quorum g1
 	}
 }
 
-func TestNewWitnessGroupFromPolicy_Errors(t *testing.T) {
+func TestParsePolicy_Errors(t *testing.T) {
 	testCases := []struct {
 		desc   string
 		policy string
@@ -164,7 +164,7 @@ func TestNewWitnessGroupFromPolicy_Errors(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			_, err := NewWitnessGroupFromPolicy([]byte(tc.policy))
+			_, err := ParsePolicy([]byte(tc.policy))
 			if err == nil {
 				t.Fatal("Expected error, got nil")
 			}


### PR DESCRIPTION
This moves the witness code, which implements https://c2sp.org/tlog-witness and https://git.glasklar.is/sigsum/core/sigsum-go/-/blob/main/doc/policy.md (with a slight variation of key format) to this low-dependency repo. Moving this out of the Tessera codebase lets verifiers verify witness cosigntures on checkpoints without also depending on Tessera, only needing transparency-dev/formats and transparency-dev/merkle.

I preserved the git history with [git-filter-repo](https://github.com/newren/git-filter-repo). When merging, this should be either merged or rebased onto main to preserve the history. Also note the license remains unchanged.