### PR TITLE
Guard against over-length origins

### DIFF
--- a/note/note_cosigv1.go
+++ b/note/note_cosigv1.go
@@ -391,6 +391,9 @@ func formatMLDSACosignatureV1(cosignerName string, timestamp uint64, logOrigin s
 	if start > 0 && timestamp > 0 {
 		return nil, errInvalidTimestamp
 	}
+	if len(logOrigin) > 255 || len(cosignerName) > 255 {
+		return nil, errSignerID
+	}
 
 	// The signed message is a binary TLS presentation encoding of the
 	// following structure:
@@ -499,6 +502,9 @@ func (v *SubtreeVerifier) VerifySubtree(timestamp uint64, logOrigin string, star
 // isValidName reports whether name is valid.
 // It must be non-empty and not have any Unicode spaces or pluses.
 func isValidName(name string) bool {
+	if len(name) > 255 {
+		return false
+	}
 	return name != "" && utf8.ValidString(name) && strings.IndexFunc(name, unicode.IsSpace) < 0 && !strings.Contains(name, "+")
 }
 

--- a/note/note_cosigv1_test.go
+++ b/note/note_cosigv1_test.go
@@ -6,6 +6,7 @@ package note
 
 import (
 	"crypto/rand"
+	"strings"
 	"testing"
 	"time"
 
@@ -48,7 +49,41 @@ func TestSignerRoundtrip(t *testing.T) {
 	}
 }
 
-func TestCosignnatureV1RoundTrip(t *testing.T) {
+func TestFormatMLDSASignatureV1(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		cosignerName string
+		logOrigin string
+		wantErr bool
+	}{
+		{
+			name: "ok",
+			cosignerName: "mldsa",
+			logOrigin: "test",
+		},
+		{
+			name: "origin name too long",
+			cosignerName: "mldsa",
+			logOrigin: strings.Repeat("t", 256),
+			wantErr: true,
+		},
+		{
+			name: "cosigner name too long",
+			cosignerName: "mldsa"+strings.Repeat("a", 255),
+			logOrigin: "test",
+			wantErr: true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := formatMLDSACosignatureV1(test.cosignerName, 0, test.logOrigin, 0, 0, []byte{})
+			if gotErr := err != nil; gotErr != test.wantErr {
+				t.Fatalf("formatMLDSACosignatureV1: got %v", err)
+			}
+		})
+	}
+}
+
+func TestCosignatureV1RoundTrip(t *testing.T) {
 	edSk, edPk := mustGenerateEd25519Key(t, "ed25519")
 	mlSk, mlPk := mustGenerateMLDSAKey(t, "mldsa")
 	for _, test := range []struct {
@@ -338,6 +373,10 @@ func TestGenerateMLDSAKey(t *testing.T) {
 		},
 		{
 			name:    "invalid name",
+			wantErr: true,
+		},
+		{
+			name: "name-too-long"+strings.Repeat("g", 255),
 			wantErr: true,
 		},
 	} {


### PR DESCRIPTION
This PR enforces the requirement that log (and mirror) origins are no longer than 255 bytes. 

This is implicitly required by `tlog-cosignature`, which uses `uint8` when encoding origin lengths in the MLDSA cosigned message.